### PR TITLE
update favicon to use blue logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/assets/blue_logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>


### PR DESCRIPTION
This pull request includes a change to the `index.html` file. The most important change is updating the favicon link to point to a new image.

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L5-R5): Updated the favicon link to use `/src/assets/blue_logo.png` instead of `/vite.svg`.